### PR TITLE
Allow to switch the header off in `CommandLineOptionFormatter`.

### DIFF
--- a/FluentCommandLineParser/Internals/CommandLineOptionFormatter.cs
+++ b/FluentCommandLineParser/Internals/CommandLineOptionFormatter.cs
@@ -43,6 +43,7 @@ namespace Fclp.Internals
         /// </summary>
         public CommandLineOptionFormatter()
         {
+            this.ShowHeader = true;
             this.ValueText = "Value";
             this.DescriptionText = "Description";
             this.NoOptionsText = "No options have been setup";
@@ -53,6 +54,11 @@ namespace Fclp.Internals
         /// The text format used in this formatter.
         /// </summary>
         public const string TextFormat = "\t/{0}\t\t{1}\n";
+
+        /// <summary>
+        /// If true, outputs a header line above the option list. If false, the header is omitted. Default is true.
+        /// </summary>
+        public bool ShowHeader { get; set; }
 
         /// <summary>
         /// Gets or sets the text to use as <c>Value</c> header. This should be localised for the end user.
@@ -86,7 +92,8 @@ namespace Fclp.Internals
             var sb = new StringBuilder();
 
             // add headers first
-            sb.AppendFormat(CultureInfo.CurrentUICulture, TextFormat, this.ValueText, this.DescriptionText);
+            if (ShowHeader)
+                sb.AppendFormat(CultureInfo.CurrentUICulture, TextFormat, this.ValueText, this.DescriptionText);
 
             foreach (var cmdOption in list.OrderBy(x => x.ShortName))
                 sb.AppendFormat(CultureInfo.CurrentUICulture, TextFormat, FormatValue(cmdOption), cmdOption.Description);


### PR DESCRIPTION
This pull request just adds the option to turn the header off. The default behavior is unchanged.

But actually I think that the output of the header does not belong in to the default options formatter. 

The first time I saw the header in the console output, I found it quite confusing because of its similarity to an actual option. May be I am somewhat stupid, but I always thought that there is another (buggy?) option named "/Value" where the description is missing and "Description" is shown as a default :). An empty line below the header would be nice, but I personally would prefer it being switched off by default.

Also the default formatter should not be public or - if intended to be used - not in a namespace that includes "Internals". Of course people could always write their own, but it's almost preferable to configure what's already there.
