### PR TITLE
Removed requirement to have short name for every option.

### DIFF
--- a/FluentCommandLineParser.Tests/FluentCommandLineParser/when_setting_up_a_new_option/with_a_short_name/with_a_short_name_that_is_empty.cs
+++ b/FluentCommandLineParser.Tests/FluentCommandLineParser/when_setting_up_a_new_option/with_a_short_name/with_a_short_name_that_is_empty.cs
@@ -30,7 +30,7 @@ namespace Fclp.Tests.FluentCommandLineParser
 {
 	namespace when_setting_up_a_new_option
 	{
-		public class with_a_short_name_that_is_empty : SettingUpAShortOptionTestContext
+		public class with_a_short_name_that_is_empty_and_a_long_name_that_is_empty : SettingUpAShortOptionTestContext
 		{
 			Establish context = AutoMockAll;
 

--- a/FluentCommandLineParser.Tests/FluentCommandLineParserTests.cs
+++ b/FluentCommandLineParser.Tests/FluentCommandLineParserTests.cs
@@ -356,9 +356,31 @@ namespace Fclp.Tests
 
 		#endregion DateTime Option
 
-		#region Required
+        #region Long Option Only
 
-		[Test]
+        [Test]
+        public void Can_have_long_option_only()
+        {
+            var parser = CreateFluentParser();
+            var s = "";
+
+            parser.Setup<string>(null, "my-feature")
+                  .Callback(val => s = val);
+
+            var result = parser.Parse(new[] { "--my-feature", "somevalue" });
+
+            Assert.IsFalse(result.HasErrors);
+            Assert.IsFalse(result.EmptyArgs);
+            Assert.IsFalse(result.HelpCalled);
+
+            Assert.AreEqual("somevalue", s);
+        }
+
+        #endregion
+
+        #region Required
+
+        [Test]
 		public void Ensure_Expected_Error_Is_Returned_If_A_Option_Is_Required_And_Null_Args_Are_Specified()
 		{
 			var parser = CreateFluentParser();
@@ -558,48 +580,66 @@ namespace Fclp.Tests
 
 		#region Example
 
-		[Test]
-		public void Ensure_Example_Works_As_Expected()
-		{
-			const int expectedRecordId = 10;
-			const string expectedValue = "Mr. Smith";
-			const bool expectedSilentMode = true;
+        [Test]
+        public void Ensure_Example_Works_As_Expected()
+        {
+            const int expectedRecordId = 10;
+            const string expectedValue = "Mr. Smith";
+            const bool expectedSilentMode = true;
+            const bool expectedSwitchA = true;
+            const bool expectedSwitchB = true;
+            const bool expectedSwitchC = false;
 
-			var args = new[] { "-r", expectedRecordId.ToString(CultureInfo.InvariantCulture), "-v", "\"Mr. Smith\"", "--silent" };
+            var args = new[] { "-r", expectedRecordId.ToString(CultureInfo.InvariantCulture), "-v", "\"Mr. Smith\"", "--silent", "-ab", "-c-" };
 
-			int recordId = 0;
-			string newValue = null;
-			bool inSilentMode = false;
+            int recordId = 0;
+            string newValue = null;
+            bool inSilentMode = false;
+            bool switchA = false;
+            bool switchB = false;
+            bool switchC = true;
 
-			IFluentCommandLineParser parser = CreateFluentParser();
+            IFluentCommandLineParser parser = CreateFluentParser();
 
-			// create a new Option using a short and long name
-			parser.Setup<int>("r", "record")
-					.WithDescription("The record id to update (required)")
-					.Callback(record => recordId = record) // use callback to assign the record value to the local RecordID property
-					.Required(); // fail if this Option is not provided in the arguments
+            parser.Setup<bool>("a")
+                  .Callback(value => switchA = value);
 
-			parser.Setup<string>("v", "value")
-					.WithDescription("The new value for the record (required)") // used when help is requested e.g -? or --help 
-					.Callback(value => newValue = value)
-					.Required();
+            parser.Setup<bool>("b")
+                  .Callback(value => switchB = value);
 
-			// create an optional Option
-			parser.Setup<bool>("s", "silent")
-					.WithDescription("Execute the update in silent mode without feedback (default is false)")
-					.Callback(silent => inSilentMode = silent)
-					.SetDefault(false); // explicitly set the default value to use if this Option is not specified in the arguments
+            parser.Setup<bool>("c")
+                  .Callback(value => switchC = value);
 
-			// do the work
-			ICommandLineParserResult result = parser.Parse(args);
+            // create a new Option using a short and long name
+            parser.Setup<int>("r", "record")
+                    .WithDescription("The record id to update (required)")
+                    .Callback(record => recordId = record) // use callback to assign the record value to the local RecordID property
+                    .Required(); // fail if this Option is not provided in the arguments
 
-			Assert.IsFalse(result.HasErrors);
-			Assert.IsFalse(result.Errors.Any());
+            parser.Setup<bool>(null, "silent")
+                  .WithDescription("Execute the update in silent mode without feedback (default is false)")
+                  .Callback(silent => inSilentMode = silent)
+                  .SetDefault(false); // explicitly set the default value to use if this Option is not specified in the arguments
 
-			Assert.AreEqual(expectedRecordId, recordId);
-			Assert.AreEqual(expectedValue, newValue);
-			Assert.AreEqual(expectedSilentMode, inSilentMode);
-		}
+
+            parser.Setup<string>("v", "value")
+                    .WithDescription("The new value for the record (required)") // used when help is requested e.g -? or --help 
+                    .Callback(value => newValue = value)
+                    .Required();
+
+            // do the work
+            ICommandLineParserResult result = parser.Parse(args);
+
+            Assert.IsFalse(result.HasErrors);
+            Assert.IsFalse(result.Errors.Any());
+
+            Assert.AreEqual(expectedRecordId, recordId);
+            Assert.AreEqual(expectedValue, newValue);
+            Assert.AreEqual(expectedSilentMode, inSilentMode);
+            Assert.AreEqual(expectedSwitchA, switchA);
+            Assert.AreEqual(expectedSwitchB, switchB);
+            Assert.AreEqual(expectedSwitchC, switchC);
+        }
 
 		#endregion
 

--- a/FluentCommandLineParser.Tests/Internals/CommandLineOptionTests.cs
+++ b/FluentCommandLineParser.Tests/Internals/CommandLineOptionTests.cs
@@ -89,39 +89,150 @@ namespace FluentCommandLineParser.Tests.Internals
 		}
 
 		[Test]
-		[ExpectedException(typeof(ArgumentOutOfRangeException))]
-		public void Ensure_Cannot_Be_Constructed_With_Null_ShortName()
+		public void Ensure_Can_Be_Constructed_With_Null_ShortName_And_Valid_LongName()
 		{
 			const string expectedShortName = null;
 			const string expectedLongName = "My long name";
 
 			var mockParser = Mock.Of<ICommandLineOptionParser<object>>();
 
-			new CommandLineOption<object>(expectedShortName, expectedLongName, mockParser);
+			var cmdOption = new CommandLineOption<object>(expectedShortName, expectedLongName, mockParser);
+
+            Assert.AreEqual(expectedShortName, cmdOption.ShortName, "Could not instantiate with null ShortName");
 		}
 
 		[Test]
-		[ExpectedException(typeof(ArgumentOutOfRangeException))]
-		public void Ensure_Cannot_Be_Constructed_With_Empty_ShortName()
+		public void Ensure_Can_Be_Constructed_With_Empty_ShortName_And_Valid_LongName()
 		{
 			const string expectedShortName = "";
 			const string expectedLongName = "My long name";
 			var mockParser = Mock.Of<ICommandLineOptionParser<object>>();
 
-			new CommandLineOption<object>(expectedShortName, expectedLongName, mockParser);
+			var cmdOption = new CommandLineOption<object>(expectedShortName, expectedLongName, mockParser);
+
+            Assert.AreEqual(expectedShortName, cmdOption.ShortName, "Could not instantiate with empty ShortName");
 		}
 
 		[Test]
-		[ExpectedException(typeof(ArgumentOutOfRangeException))]
-		public void Ensure_Cannot_Be_Constructed_With_Whitespace_Only_ShortName()
+		public void Ensure_Can_Be_Constructed_With_Whitespace_Only_ShortName_And_Valid_LongName()
 		{
 			const string expectedShortName = " ";
 			const string expectedLongName = "My long name";
 			var mockParser = Mock.Of<ICommandLineOptionParser<object>>();
 
-			new CommandLineOption<object>(expectedShortName, expectedLongName, mockParser);
+			var cmdOption = new CommandLineOption<object>(expectedShortName, expectedLongName, mockParser);
+
+            Assert.AreEqual(expectedShortName, cmdOption.ShortName, "Could not instantiate with whitespace only ShortName");
 		}
 
+        [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Ensure_Cannot_Be_Constructed_With_Null_ShortName_And_Null_LongName()
+        {
+            const string invalidShortName = null;
+            const string invalidLongName = null;
+            
+            var mockParser = Mock.Of<ICommandLineOptionParser<object>>();
+
+            new CommandLineOption<object>(invalidShortName, invalidLongName, mockParser);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Ensure_Cannot_Be_Constructed_With_Empty_ShortName_And_Null_LongName()
+        {
+            const string invalidShortName = "";
+            const string invalidLongName = null;
+
+            var mockParser = Mock.Of<ICommandLineOptionParser<object>>();
+
+            new CommandLineOption<object>(invalidShortName, invalidLongName, mockParser);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Ensure_Cannot_Be_Constructed_With_WhiteSpaceOnly_ShortName_And_Null_LongName()
+        {
+            const string invalidShortName = " ";
+            const string invalidLongName = null;
+
+            var mockParser = Mock.Of<ICommandLineOptionParser<object>>();
+
+            new CommandLineOption<object>(invalidShortName, invalidLongName, mockParser);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Ensure_Cannot_Be_Constructed_With_Null_ShortName_And_Empty_LongName()
+        {
+            const string invalidShortName = null;
+            const string invalidLongName = "";
+
+            var mockParser = Mock.Of<ICommandLineOptionParser<object>>();
+
+            new CommandLineOption<object>(invalidShortName, invalidLongName, mockParser);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Ensure_Cannot_Be_Constructed_With_Empty_ShortName_And_Empty_LongName()
+        {
+            const string invalidShortName = "";
+            const string invalidLongName = "";
+
+            var mockParser = Mock.Of<ICommandLineOptionParser<object>>();
+
+            new CommandLineOption<object>(invalidShortName, invalidLongName, mockParser);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Ensure_Cannot_Be_Constructed_With_WhiteSpaceOnly_ShortName_And_Empty_LongName()
+        {
+            const string invalidShortName = " ";
+            const string invalidLongName = "";
+
+            var mockParser = Mock.Of<ICommandLineOptionParser<object>>();
+
+            new CommandLineOption<object>(invalidShortName, invalidLongName, mockParser);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Ensure_Cannot_Be_Constructed_With_Null_ShortName_And_WhiteSpaceOnly_LongName()
+        {
+            const string invalidShortName = null;
+            const string invalidLongName = " ";
+
+            var mockParser = Mock.Of<ICommandLineOptionParser<object>>();
+
+            new CommandLineOption<object>(invalidShortName, invalidLongName, mockParser);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Ensure_Cannot_Be_Constructed_With_Empty_ShortName_And_WhiteSpaceOnly_LongName()
+        {
+            const string invalidShortName = "";
+            const string invalidLongName = " ";
+
+            var mockParser = Mock.Of<ICommandLineOptionParser<object>>();
+
+            new CommandLineOption<object>(invalidShortName, invalidLongName, mockParser);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Ensure_Cannot_Be_Constructed_With_WhiteSpaceOnly_ShortName_And_WhiteSpaceOnly_LongName()
+        {
+            const string invalidShortName = " ";
+            const string invalidLongName = " ";
+
+            var mockParser = Mock.Of<ICommandLineOptionParser<object>>();
+
+            new CommandLineOption<object>(invalidShortName, invalidLongName, mockParser);
+        }
+        
 		[Test]
 		[ExpectedException(typeof(ArgumentNullException))]
 		public void Ensure_Cannot_Be_Constructed_With_Null_Parser()

--- a/FluentCommandLineParser/FluentCommandLineParser.cs
+++ b/FluentCommandLineParser/FluentCommandLineParser.cs
@@ -123,10 +123,11 @@ namespace Fclp
 		{
 			EnsureIsValidShortName(shortOption);
 			EnsureIsValidLongName(longOption);
+		    EnsureHasShortNameOrLongName(shortOption, longOption);
 
 			foreach (var option in this.Options)
 			{
-				if (shortOption.Equals(option.ShortName, this.StringComparison))
+				if (shortOption != null && shortOption.Equals(option.ShortName, this.StringComparison))
 					throw new OptionAlreadyExistsException(shortOption);
 
 				if (longOption != null && longOption.Equals(option.LongName, this.StringComparison))
@@ -145,6 +146,8 @@ namespace Fclp
 
 		private static void EnsureIsValidShortName(string value)
 		{
+		    if (string.IsNullOrEmpty(value)) return;
+
 			var invalidChars = SpecialCharacters.ValueAssignments.Union(new[] { SpecialCharacters.Whitespace });
 			if (value.IsNullOrWhiteSpace() || invalidChars.Any(value.Contains) || value.Length > 1)
 				throw new ArgumentOutOfRangeException("value");
@@ -161,6 +164,12 @@ namespace Fclp
 			if (invalidChars.Any(value.Contains))
 				throw new ArgumentOutOfRangeException("value");
 		}
+
+        private static void EnsureHasShortNameOrLongName(string shortOption, string longOption)
+        {
+            if (shortOption.IsNullOrWhiteSpace() && longOption.IsNullOrWhiteSpace())
+                throw new ArgumentOutOfRangeException("shortOption", "Either shortOption or longOption must be specified");
+        }
 
 		/// <summary>
 		/// Setup a new <see cref="ICommandLineOptionFluent{T}"/> using the specified short Option name.

--- a/FluentCommandLineParser/Internals/CommandLineOption.cs
+++ b/FluentCommandLineParser/Internals/CommandLineOption.cs
@@ -23,14 +23,13 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Fclp.Internals.Extensions;
 using Fclp.Internals.Parsers;
 
 namespace Fclp.Internals
 {
-	/// <summary>
+    /// <summary>
 	/// A command line Option
 	/// </summary>
 	/// <typeparam name="T">The type of value this Option requires.</typeparam>
@@ -41,14 +40,16 @@ namespace Fclp.Internals
 		/// <summary>
 		/// Initialises a new instance of the <see cref="CommandLineOption{T}"/> class.
 		/// </summary>
-		/// <param name="shortName">The short name for this Option. This must not be <c>null</c>, <c>empty</c> or contain only <c>whitespace</c>.</param>
-		/// <param name="longName">The long name for this Option or <c>null</c> if not required.</param>
+		/// <param name="shortName">The short name for this Option or <c>null</c> if not required. Either <paramref name="shortName"/> or <paramref name="longName"/> must not be <c>null</c>, <c>empty</c> or contain only <c>whitespace</c>.</param>
+        /// <param name="longName">The long name for this Option or <c>null</c> if not required. Either <paramref name="shortName"/> or <paramref name="longName"/> must not be <c>null</c>, <c>empty</c> or contain only <c>whitespace</c>.</param>
 		/// <param name="parser">The parser to use for this Option.</param>
-		/// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="shortName"/> is <c>null</c>, <c>empty</c> or contains only <c>whitespace</c>.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">Thrown if both <paramref name="shortName"/> and <paramref name="longName"/> are <c>null</c>, <c>empty</c> or contain only <c>whitespace</c>.</exception>
 		/// <exception cref="ArgumentNullException">If <paramref name="parser"/> is <c>null</c>.</exception>
 		public CommandLineOption(string shortName, string longName, ICommandLineOptionParser<T> parser)
 		{
-			if (shortName.IsNullOrWhiteSpace()) throw new ArgumentOutOfRangeException("shortName");
+		    if (shortName.IsNullOrWhiteSpace() && longName.IsNullOrWhiteSpace())
+		        throw new ArgumentOutOfRangeException("shortName", "shortName and longName cannot both be null");
+
 			if (parser == null) throw new ArgumentNullException("parser");
 
 			this.ShortName = shortName;


### PR DESCRIPTION
Implementation for issue #14. Pull Request moved to develop branch.

<code>CommandLineOption</code> can now be constructed with a null/empty/whitespace short name, provided a long name is also specified. New tests added to reflect this (in <code>FluentCommandLineParserTests</code>).

<code>Setup&ltT&gt(string shortOption, string longOption)</code> throws an <code>ArgumentOutOfRangeException</code> for <code>shortOption</code> if neither is specified.

The example in <code>FluentCommandLineParserTests</code> is updated to include an option which has only a long name and no specified short name, and also with an option group to ensure that this functionality is not broken by the changes.
