### PR TITLE
Fixed double parsing on french computers where "125.23" wasn't parsed as...

### DIFF
--- a/FluentCommandLineParser/Internals/Parsing/OptionParsers/DoubleCommandLineOptionParser.cs
+++ b/FluentCommandLineParser/Internals/Parsing/OptionParsers/DoubleCommandLineOptionParser.cs
@@ -38,7 +38,7 @@ namespace Fclp.Internals.Parsing.OptionParsers
 		/// <returns></returns>
 		public double Parse(ParsedOption parsedOption)
 		{
-			return double.Parse(parsedOption.Value, CultureInfo.CurrentCulture);
+			return double.Parse(parsedOption.Value, CultureInfo.InvariantCulture);
 		}
 
 		/// <summary>
@@ -49,7 +49,7 @@ namespace Fclp.Internals.Parsing.OptionParsers
 		public bool CanParse(ParsedOption parsedOption)
 		{
 			double result;
-			return double.TryParse(parsedOption.Value, out result);
+            return double.TryParse(parsedOption.Value, System.Globalization.NumberStyles.Number, CultureInfo.InvariantCulture, out result);
 		}
 	}
 }


### PR DESCRIPTION
... double because it expected "125,23".

Two tests were failing because of this.
Used InvariantCulture to fix this instead of CurrentCulture.
