### PR TITLE
DateTime parsing fix for #48

### DIFF
--- a/FluentCommandLineParser.Tests/FluentCommandLineParserTests.cs
+++ b/FluentCommandLineParser.Tests/FluentCommandLineParserTests.cs
@@ -734,6 +734,59 @@ namespace Fclp.Tests
             Assert.IsFalse(result.Errors.Any());
         }
 
+        [Test]
+        public void Ensure_Parser_Calls_The_Callback_With_Expected_DateTime_When_Using_Spaces_And_Long_option()
+        {
+            var expected = new DateTime(2012, 2, 29, 01, 01, 01);
+
+            DateTime actual = default(DateTime);
+
+            var parser = CreateFluentParser();
+
+            parser
+                .Setup<DateTime>('d', "datetime")
+                .Callback(val => actual = val);
+
+            var result = parser.Parse(new[] { "--datetime", expected.ToString("dd MM yyyy hh:mm:ss tt", CultureInfo.CurrentCulture) });
+
+            Assert.AreEqual(expected, actual);
+            Assert.IsFalse(result.HasErrors);
+            Assert.IsFalse(result.Errors.Any());
+        }
+
+        [Test]
+        public void Ensure_Parser_Calls_The_Callback_With_Expected_DateTime_When_Using_Spaces_And_Short_option()
+        {
+            var expected = new DateTime(2012, 2, 29, 01, 01, 01);
+            RunTest(expected.ToString("dd MM yyyy hh:mm:ss tt", CultureInfo.InvariantCulture), expected);
+        }
+
+        [Test]
+        public void Ensure_Parser_Calls_The_Callback_With_Expected_ListDateTime_When_Using_Spaces_And_Long_option()
+        {
+            var expected = new List<DateTime> {
+                new DateTime(2012, 2, 29, 01, 01, 01),
+                new DateTime(12,12,12,12,12,12),
+                new DateTime(11,11,11)
+            };
+
+            List<DateTime> actual = new List<DateTime>();
+
+            var parser = CreateFluentParser();
+
+            parser
+                .Setup<List<DateTime>>('d', "datetime")
+                .Callback(val => actual = val);
+
+            var dArgs = new List<string> { "--datetime" };
+            dArgs.AddRange(expected.Select(x => "\"" + x.ToString("dd MM yyyy hh:mm:ss tt", CultureInfo.CurrentCulture) + "\""));
+            var result = parser.Parse(dArgs.ToArray());
+
+            Assert.AreEqual(expected, actual);
+            Assert.IsFalse(result.HasErrors);
+            Assert.IsFalse(result.Errors.Any());
+        }
+
         #endregion DateTime Option
 
         #region int? Option

--- a/FluentCommandLineParser/Internals/Parsing/OptionParsers/DateTimeCommandLineOptionParser.cs
+++ b/FluentCommandLineParser/Internals/Parsing/OptionParsers/DateTimeCommandLineOptionParser.cs
@@ -39,7 +39,7 @@ namespace Fclp.Internals.Parsing.OptionParsers
 		/// <returns></returns>
 		public DateTime Parse(ParsedOption parsedOption)
 		{
-			return DateTime.Parse(parsedOption.Value, CultureInfo.CurrentCulture);
+			return DateTime.Parse(parsedOption.Value.Trim('"'), CultureInfo.CurrentCulture);
 		}
 
 		/// <summary>
@@ -50,7 +50,7 @@ namespace Fclp.Internals.Parsing.OptionParsers
 		public bool CanParse(ParsedOption parsedOption)
 		{
 			DateTime dtOut;
-			return DateTime.TryParse(parsedOption.Value, out dtOut);
+			return DateTime.TryParse(parsedOption.Value.Trim('"'), out dtOut);
 		}
 	}
 }

--- a/FluentCommandLineParser/Internals/Parsing/OptionParsers/DateTimeCommandLineOptionParser.cs
+++ b/FluentCommandLineParser/Internals/Parsing/OptionParsers/DateTimeCommandLineOptionParser.cs
@@ -50,7 +50,7 @@ namespace Fclp.Internals.Parsing.OptionParsers
 		public bool CanParse(ParsedOption parsedOption)
 		{
 			DateTime dtOut;
-			return DateTime.TryParse(parsedOption.Value.Trim('"'), out dtOut);
+			return DateTime.TryParse((parsedOption.Value ?? string.Empty).Trim('"'), out dtOut);
 		}
 	}
 }


### PR DESCRIPTION
DateTime args that are provided with a spaces have their `ParsedOption.Value` surrounded in quotes, causesing .NET's `DateTime` parsing to fail. 

Proposed fix is to simply trim the quotes when parsing to generate expected values.
