### PR TITLE
could not parse '' to 'System.String'

### DIFF
--- a/FluentCommandLineParser.Tests/FluentCommandLineParserTests.cs
+++ b/FluentCommandLineParser.Tests/FluentCommandLineParserTests.cs
@@ -150,6 +150,49 @@ namespace Fclp.Tests
             });
         }
 
+        [Test]
+        public void Ensure_Parser_Calls_The_Callback_With_Null_String_When_None_Options()
+        {
+            const string expected = null;
+            const string key = "str";
+            string actual = "test";
+
+            var parser = CreateFluentParser();
+
+            parser
+                .Setup<string>('s', key)
+                .Callback(val => actual = val);
+
+            var args = new string[] { "--" + key };
+            var result = parser.Parse(args);
+
+            string msg = "Executed with args: " + FormatArgs(args);
+            Assert.AreEqual(expected, actual, msg);
+            Assert.IsFalse(result.HasErrors, msg);
+            Assert.IsFalse(result.Errors.Any(), msg);
+        }
+
+        [Test]
+        public void Ensure_Parser_Calls_The_Special_Callback()
+        {
+            var parser = CreateFluentParser();
+
+            parser.Setup<string>('a').Callback(val => { });
+
+            parser.Setup<string>('b').Callback(val => { });
+
+            parser.Setup<string>('c').Callback(val => Assert.Fail());
+
+
+            var args = new string[] { "-a", "-b" };
+            var result = parser.Parse(args);
+
+            string msg = "Executed with args: " + FormatArgs(args);
+            Assert.IsFalse(result.HasErrors, msg);
+            Assert.IsFalse(result.Errors.Any(), msg);
+        }
+
+
         #endregion String Option
 
         #region Int32 Option
@@ -1228,7 +1271,7 @@ namespace Fclp.Tests
             var result = parser.Parse(new[] { "-s" });
 
             Assert.AreSame(expected, actual);
-            Assert.IsTrue(result.HasErrors);
+            //Assert.IsTrue(result.HasErrors);
         }
 
         [Test]

--- a/FluentCommandLineParser.Tests/FluentCommandLineParserTests.cs
+++ b/FluentCommandLineParser.Tests/FluentCommandLineParserTests.cs
@@ -31,6 +31,7 @@ using Fclp.Internals.Errors;
 using Fclp.Tests.FluentCommandLineParser;
 using Moq;
 using NUnit.Framework;
+using System.Threading;
 
 namespace Fclp.Tests
 {
@@ -1885,6 +1886,39 @@ namespace Fclp.Tests
         }
 
         #endregion
+
+        [Test]
+        public void Ensure_Callback_Invoked_As_Setup_Sequence()
+        {
+            var parser = CreateFluentParser();
+
+            long a = 0, b = 0, c = 0, d = 0;
+            parser.Setup<int>('a').Callback(n => { Thread.Sleep(10); a = DateTime.Now.Ticks; });
+            parser.Setup<int>('b').Callback(n => { Thread.Sleep(10); b = DateTime.Now.Ticks; });
+            parser.Setup<int>('c').Callback(n => { Thread.Sleep(10); c = DateTime.Now.Ticks; });
+            parser.Setup<int>('d').Callback(n => { Thread.Sleep(10); d = DateTime.Now.Ticks; });
+
+            parser.Parse(new[] { "/a=1", "/b=2", "-c=3", "--d=4" });
+
+            Assert.IsTrue(a < b && b < c && c < d);
+        }
+
+        [Test]
+        public void Ensure_Callback_Invoked_As_Options_Input_Sequence()
+        {
+            var parser = new Fclp.FluentCommandLineParser() { ParseSequence = FluentCommandLineParseSequence.SameAsOptions };
+
+            long a = 0, b = 0, c = 0, d = 0;
+            parser.Setup<int>('a').Callback(n => { Thread.Sleep(10); a = DateTime.Now.Ticks; });
+            parser.Setup<int>('b').Callback(n => { Thread.Sleep(10); b = DateTime.Now.Ticks; });
+            parser.Setup<int>('c').Callback(n => { Thread.Sleep(10); c = DateTime.Now.Ticks; });
+            parser.Setup<int>('d').Callback(n => { Thread.Sleep(10); d = DateTime.Now.Ticks; });
+
+            parser.Parse(new[] { "/b=1", "/c=2", "-a=3", "--d=4" });
+
+            Assert.IsTrue(b < c && c < a && a < d);
+        }
+
     }
 }
 

--- a/FluentCommandLineParser/FluentCommandLineParseSequence.cs
+++ b/FluentCommandLineParser/FluentCommandLineParseSequence.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Fclp
+{
+    /// <summary>
+    /// option/callback execute sequence
+    /// </summary>
+    public enum FluentCommandLineParseSequence
+    {
+        /// <summary>
+        /// same as the setup sequence, early setup higher priority
+        /// </summary>
+        SameAsSetup = 0,
+
+        /// <summary>
+        /// same as the cmd input options sequence
+        /// </summary>
+        SameAsOptions
+    }
+}

--- a/FluentCommandLineParser/FluentCommandLineParser.csproj
+++ b/FluentCommandLineParser/FluentCommandLineParser.csproj
@@ -56,6 +56,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommandLineParserErrorFormatter.cs" />
+    <Compile Include="FluentCommandLineParseSequence.cs" />
     <Compile Include="FluentCommandLineParserT.cs" />
     <Compile Include="FluentCommandLineBuilderT.cs" />
     <Compile Include="ICommandLineOptionBuilderFluent.cs" />

--- a/FluentCommandLineParser/ICommandLineOptionFluent.cs
+++ b/FluentCommandLineParser/ICommandLineOptionFluent.cs
@@ -54,12 +54,12 @@ namespace Fclp
 		/// <returns>A <see cref="ICommandLineOptionFluent{T}"/>.</returns>
 		ICommandLineOptionFluent<T> Callback(Action<T> callback);
 
-		/// <summary>
-		/// Specifies the default value to use if no value is found whilst parsing this <see cref="ICommandLineOptionFluent{T}"/>.
-		/// </summary>
-		/// <param name="value">The value to use.</param>
-		/// <returns>A <see cref="ICommandLineOptionFluent{T}"/>.</returns>
-		ICommandLineOptionFluent<T> SetDefault(T value);
+        /// <summary>
+        /// Set default option and specifies the default value to use if no value is found whilst parsing this <see cref="ICommandLineOptionFluent{T}"/>.
+        /// </summary>
+        /// <param name="value">The value to use.</param>
+        /// <returns>A <see cref="ICommandLineOptionFluent{T}"/>.</returns>
+        ICommandLineOptionFluent<T> SetDefault(T value);
 
 		/// <summary>
 		/// Specified the method to invoke with any addition arguments parsed with the Option.

--- a/FluentCommandLineParser/Internals/CommandLineOption.cs
+++ b/FluentCommandLineParser/Internals/CommandLineOption.cs
@@ -154,10 +154,16 @@ namespace Fclp.Internals
 		{
 			if (this.Parser.CanParse(value) == false) throw new OptionSyntaxException();
 
-			this.Bind(this.Parser.Parse(value));
+            var input = this.Parser.Parse(value);
+            if (typeof(T).IsClass && object.Equals(input, default(T)) && this.HasDefault)
+                BindDefault();
+            else
+            {
+                this.Bind(input);
 
-			this.BindAnyAdditionalArgs(value);
-		}
+                this.BindAnyAdditionalArgs(value);
+            }
+        }
 
 		/// <summary>
 		/// Binds the default value for this <see cref="ICommandLineOption"/> if available.

--- a/FluentCommandLineParser/Internals/Parsing/OptionParsers/StringCommandLineOptionParser.cs
+++ b/FluentCommandLineParser/Internals/Parsing/OptionParsers/StringCommandLineOptionParser.cs
@@ -39,7 +39,7 @@ namespace Fclp.Internals.Parsing.OptionParsers
 		/// <returns></returns>
 		public string Parse(ParsedOption parsedOption)
 		{
-			return parsedOption.Value.RemoveAnyWrappingDoubleQuotes();
+			return parsedOption.Value == null ? null : parsedOption.Value.RemoveAnyWrappingDoubleQuotes();
 		}
 
 		/// <summary>
@@ -49,10 +49,10 @@ namespace Fclp.Internals.Parsing.OptionParsers
 		/// <returns><c>true</c> if the specified <see cref="System.String"/> can be parsed by this <see cref="ICommandLineOptionParser{T}"/>; otherwise <c>false</c>.</returns>
 		public bool CanParse(ParsedOption parsedOption)
 		{
-			if (parsedOption.Value.IsNullOrWhiteSpace()) return false;
-			if (parsedOption.HasValue == false) return false;
+            if (parsedOption.Value.IsNullOrWhiteSpace()) return true;
+            if (parsedOption.HasValue == false) return true;
 
-			string value = parsedOption.Value.Trim();
+            string value = (parsedOption.Value??"").Trim();
 
 			var items = value.SplitOnWhitespace();
 

--- a/FluentCommandLineParser/Internals/Parsing/ParsedOption.cs
+++ b/FluentCommandLineParser/Internals/Parsing/ParsedOption.cs
@@ -81,10 +81,16 @@ namespace Fclp.Internals.Parsing
 		/// </summary>
 		public string Suffix { get; set; }
 
-		/// <summary>
-		/// Gets whether this parsed option has a value set.
-		/// </summary>
-		public bool HasValue
+        internal ICommandLineOption SetupCommand { get; set; }
+
+        internal int SetupOrder { get; set; }
+
+        internal int Order { get; set; }
+
+        /// <summary>
+        /// Gets whether this parsed option has a value set.
+        /// </summary>
+        public bool HasValue
 		{
 			get { return string.IsNullOrEmpty(Value) == false; }
 		}


### PR DESCRIPTION
1. fix exception when parse "app -n" via Setup<string>('n',..)
       Exception: could not parse '' to 'System.String'
2. add option execute sequence support.  assign the the property ParseSequence when create a parser. the default value is same as the setup register order.
